### PR TITLE
Expose time correction as a manual preference.

### DIFF
--- a/res/xml/preferences_time_correction.xml
+++ b/res/xml/preferences_time_correction.xml
@@ -25,6 +25,11 @@
       android:targetClass="com.google.android.apps.authenticator.timesync.SyncNowActivity">
     </intent>
   </PreferenceScreen>
+  <EditTextPreference
+      android:defaultValue="0"
+      android:inputType="numberSigned"
+      android:key="timeCorrectionMinutes"
+      android:title="Adjustment in minutes" />
   <PreferenceScreen
     android:key="about"
     android:title="@string/timesync_about_feature_preference_title"


### PR DESCRIPTION
This allows it to be changed without a connection to the internet.
